### PR TITLE
설문지 완료 , 완료된 설문지 확인 기능 추가 및 일부 기능 수정

### DIFF
--- a/src/answer/answer.module.ts
+++ b/src/answer/answer.module.ts
@@ -9,6 +9,6 @@ import { OptionModule } from '../option/option.module';
 @Module({
   imports: [DatabaseModule, QuestionModule, OptionModule],
   providers: [AnswerService, AnswerResolver, ...AnswerRepository],
-  exports: [AnswerService],
+  exports: [AnswerService, ...AnswerRepository],
 })
 export class AnswerModule {}

--- a/src/answer/answer.module.ts
+++ b/src/answer/answer.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { AnswerService } from './answer.service';
 import { AnswerResolver } from './answer.resolver';
 import { AnswerRepository } from './answer.repository';
@@ -7,7 +7,11 @@ import { QuestionModule } from '../question/question.module';
 import { OptionModule } from '../option/option.module';
 
 @Module({
-  imports: [DatabaseModule, QuestionModule, OptionModule],
+  imports: [
+    DatabaseModule,
+    forwardRef(() => QuestionModule),
+    forwardRef(() => OptionModule),
+  ],
   providers: [AnswerService, AnswerResolver, ...AnswerRepository],
   exports: [AnswerService, ...AnswerRepository],
 })

--- a/src/answer/answer.resolver.ts
+++ b/src/answer/answer.resolver.ts
@@ -2,8 +2,11 @@ import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
 import { AnswerService } from './answer.service';
 import { Answer } from './answer.entity';
 import { CreateAnswerInput, UpdateAnswerInput } from './dto/answer.input';
+import { UseFilters } from '@nestjs/common';
+import { GqlHttpExceptionFilter } from '../base/filters/gql-http-exception.filter';
 
 @Resolver((of) => Answer)
+@UseFilters(GqlHttpExceptionFilter)
 export class AnswerResolver {
   constructor(private answerService: AnswerService) {}
 

--- a/src/base/filters/gql-http-exception.filter.ts
+++ b/src/base/filters/gql-http-exception.filter.ts
@@ -1,0 +1,33 @@
+import { ArgumentsHost, Catch, HttpException } from '@nestjs/common';
+import { GqlExceptionFilter } from '@nestjs/graphql';
+import { ApolloError } from 'apollo-server-express';
+
+@Catch(HttpException)
+export class GqlHttpExceptionFilter implements GqlExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const status = exception.getStatus();
+    const response = exception.getResponse();
+
+    const errorMessage =
+      typeof response === 'string' ? response : response['message'];
+
+    const errorCode = this.getErrorCode(status);
+
+    return new ApolloError(errorMessage, errorCode, {
+      httpStatusCode: status,
+    });
+  }
+
+  private getErrorCode(statusCode: number): string {
+    switch (statusCode) {
+      case 404:
+        return 'NOT_FOUND';
+      case 403:
+        return 'FORBIDDEN';
+      case 401:
+        return 'UNAUTHORIZED';
+      default:
+        return 'INTERNAL_SERVER_ERROR';
+    }
+  }
+}

--- a/src/option/option.module.ts
+++ b/src/option/option.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { OptionService } from './option.service';
 import { OptionResolver } from './option.resolver';
 import { OptionRepository } from './option.repository';
@@ -6,7 +6,7 @@ import { DatabaseModule } from '../database/database.module';
 import { QuestionModule } from '../question/question.module';
 
 @Module({
-  imports: [DatabaseModule, QuestionModule],
+  imports: [DatabaseModule, forwardRef(() => QuestionModule)],
   providers: [OptionService, OptionResolver, ...OptionRepository],
   exports: [OptionService, ...OptionRepository],
 })

--- a/src/option/option.resolver.ts
+++ b/src/option/option.resolver.ts
@@ -2,8 +2,11 @@ import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
 import { OptionService } from './option.service';
 import { Option } from './option.entity';
 import { CreateOptionInput, UpdateOptionInput } from './dto/option.input';
+import { UseFilters } from '@nestjs/common';
+import { GqlHttpExceptionFilter } from '../base/filters/gql-http-exception.filter';
 
 @Resolver((of) => Option)
+@UseFilters(GqlHttpExceptionFilter)
 export class OptionResolver {
   constructor(private optionService: OptionService) {}
 

--- a/src/question/dto/question.input.ts
+++ b/src/question/dto/question.input.ts
@@ -1,5 +1,11 @@
 import { Field, InputType, Int } from '@nestjs/graphql';
-import { IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 @InputType()
 class QuestionInputBase {
@@ -15,9 +21,11 @@ export class CreateQuestionInput {
   @IsNotEmpty()
   content: string;
 
-  @Field(() => Int)
-  @IsInt()
-  surveyId: number;
+  @Field(() => [Int], { nullable: true })
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
+  surveyIds?: number[];
 }
 @InputType()
 export class UpdateQuestionInput extends QuestionInputBase {}

--- a/src/question/question.entity.ts
+++ b/src/question/question.entity.ts
@@ -1,11 +1,5 @@
-import {
-  Entity,
-  PrimaryGeneratedColumn,
-  Column,
-  ManyToOne,
-  OneToMany,
-} from 'typeorm';
-import { Survey } from '../survey/survey.entity';
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Survey, SurveyQuestion } from '../survey/survey.entity';
 import { Option } from '../option/option.entity';
 import { Answer } from '../answer/answer.entity';
 import { BaseEntity } from '../base/base.entity';
@@ -22,11 +16,8 @@ export class Question extends BaseEntity {
   @Column()
   content: string;
 
-  @Field(() => Survey)
-  @ManyToOne(() => Survey, (survey) => survey.questions, {
-    onDelete: 'CASCADE',
-  })
-  survey: Survey;
+  @OneToMany(() => SurveyQuestion, (surveyQuestion) => surveyQuestion.question)
+  surveyQuestions: SurveyQuestion[];
 
   @Field(() => [Option], { nullable: true })
   @OneToMany(() => Option, (option) => option.question, {

--- a/src/question/question.entity.ts
+++ b/src/question/question.entity.ts
@@ -16,6 +16,7 @@ export class Question extends BaseEntity {
   @Column()
   content: string;
 
+  @Field(() => [SurveyQuestion], { nullable: true })
   @OneToMany(() => SurveyQuestion, (surveyQuestion) => surveyQuestion.question)
   surveyQuestions: SurveyQuestion[];
 

--- a/src/question/question.module.ts
+++ b/src/question/question.module.ts
@@ -1,12 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { QuestionService } from './question.service';
 import { QuestionResolver } from './question.resolver';
 import { QuestionRepository } from './question.repository';
 import { DatabaseModule } from '../database/database.module';
 import { SurveyModule } from '../survey/survey.module';
-
 @Module({
-  imports: [DatabaseModule, SurveyModule],
+  imports: [DatabaseModule, forwardRef(() => SurveyModule)],
   providers: [QuestionService, QuestionResolver, ...QuestionRepository],
   exports: [QuestionService, ...QuestionRepository],
 })

--- a/src/question/question.resolver.ts
+++ b/src/question/question.resolver.ts
@@ -2,8 +2,11 @@ import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
 import { QuestionService } from './question.service';
 import { Question } from './question.entity';
 import { CreateQuestionInput, UpdateQuestionInput } from './dto/question.input';
+import { UseFilters } from '@nestjs/common';
+import { GqlHttpExceptionFilter } from '../base/filters/gql-http-exception.filter';
 
 @Resolver((of) => Question)
+@UseFilters(GqlHttpExceptionFilter)
 export class QuestionResolver {
   constructor(private questionService: QuestionService) {}
 

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -1,8 +1,8 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Question } from './question.entity';
 import { CreateQuestionInput, UpdateQuestionInput } from './dto/question.input';
-import { Survey } from '../survey/survey.entity';
+import { Survey, SurveyQuestion } from '../survey/survey.entity';
 
 @Injectable()
 export class QuestionService {
@@ -11,38 +11,49 @@ export class QuestionService {
     private questionRepository: Repository<Question>,
     @Inject('SURVEY_REPOSITORY')
     private surveyRepository: Repository<Survey>,
+    @Inject('SURVEY_QUESTION_REPOSITORY')
+    private surveyQuestionRepository: Repository<SurveyQuestion>,
   ) {}
 
   async create(
     createQuestionInput: CreateQuestionInput,
   ): Promise<Question[] | Question> {
-    const { surveyId, ...questionDetails } = createQuestionInput;
+    const { surveyIds, ...questionDetails } = createQuestionInput;
 
-    const survey = await this.surveyRepository.findOne({
-      where: { id: surveyId },
-    });
-    if (!survey) {
-      throw new NotFoundException(`Survey with id ${surveyId} not found`);
+    const question = this.questionRepository.create(questionDetails);
+    const savedQuestion = await this.questionRepository.save(question);
+
+    if (surveyIds && surveyIds.length > 0) {
+      const surveys = await this.surveyRepository.find({
+        where: { id: In(surveyIds) },
+      });
+      if (surveys.length !== surveyIds.length) {
+        throw new NotFoundException(`One or more surveys not found`);
+      }
+
+      const surveyQuestions = surveys.map((survey) => {
+        return this.surveyQuestionRepository.create({
+          survey: survey,
+          question: savedQuestion,
+        });
+      });
+
+      await this.surveyQuestionRepository.save(surveyQuestions);
     }
 
-    const question = this.questionRepository.create({
-      ...questionDetails,
-      survey,
-    });
-
-    return this.questionRepository.save(question);
+    return savedQuestion;
   }
 
   async findAll(): Promise<Question[]> {
     return this.questionRepository.find({
-      relations: ['survey', 'answers', 'options'],
+      relations: ['surveyQuestions', 'answers', 'options'],
     });
   }
 
   async findOne(id: number): Promise<Question> {
     const question = await this.questionRepository.findOne({
       where: { id },
-      relations: ['survey', 'answers', 'options'],
+      relations: ['surveyQuestions', 'answers', 'options'],
     });
     if (!question) {
       throw new NotFoundException(`question with ID ${id} not found`);
@@ -63,9 +74,11 @@ export class QuestionService {
   }
 
   async remove(id: number): Promise<boolean> {
+    await this.surveyQuestionRepository.delete({ question: { id } });
+
     const result = await this.questionRepository.delete(id);
     if (result.affected === 0) {
-      throw new NotFoundException(`question with ID ${id} not found`);
+      throw new NotFoundException(`Question with ID ${id} not found`);
     }
     return true;
   }

--- a/src/question/tests/question.resolver.spec.ts
+++ b/src/question/tests/question.resolver.spec.ts
@@ -50,7 +50,7 @@ describe('QuestionResolver', () => {
   });
 
   it('create a question', async () => {
-    const questionData = { content: 'Test Question', surveyId: 1 };
+    const questionData = { content: 'Test Question', surveyIds: [1] };
     const expectedQuestion = { id: 1, ...questionData };
     mockQuestionService.create.mockResolvedValue(expectedQuestion);
 

--- a/src/question/tests/question.service.spec.ts
+++ b/src/question/tests/question.service.spec.ts
@@ -182,7 +182,6 @@ describe('QuestionService', () => {
     mockQuestionRepository.findOne.mockResolvedValue(expectedQuestion);
 
     const result = await service.findOne(questionId);
-    console.log(result);
 
     expect(mockQuestionRepository.findOne).toHaveBeenCalledWith({
       where: { id: questionId },

--- a/src/survey/dto/survey.input.ts
+++ b/src/survey/dto/survey.input.ts
@@ -1,5 +1,6 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { IsBoolean, IsOptional, IsString, IsNumber } from 'class-validator';
+import { CreateAnswerInput } from '../../answer/dto/answer.input';
 
 @InputType()
 class SurveyInputBase {
@@ -26,3 +27,9 @@ export class CreateSurveyInput extends SurveyInputBase {
 }
 @InputType()
 export class UpdateSurveyInput extends SurveyInputBase {}
+
+@InputType()
+export class CompleteSurveyInput extends SurveyInputBase {
+  @Field(() => [CreateAnswerInput])
+  answers: CreateAnswerInput[];
+}

--- a/src/survey/dto/survey.input.ts
+++ b/src/survey/dto/survey.input.ts
@@ -1,5 +1,12 @@
-import { Field, InputType } from '@nestjs/graphql';
-import { IsBoolean, IsOptional, IsString, IsNumber } from 'class-validator';
+import { Field, InputType, Int } from '@nestjs/graphql';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  IsNumber,
+  IsArray,
+  IsInt,
+} from 'class-validator';
 import { CreateAnswerInput } from '../../answer/dto/answer.input';
 
 @InputType()
@@ -24,6 +31,12 @@ export class CreateSurveyInput extends SurveyInputBase {
   @Field()
   @IsString()
   title: string;
+
+  @Field(() => [Int], { nullable: true })
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
+  questionIds?: number[];
 }
 @InputType()
 export class UpdateSurveyInput extends SurveyInputBase {}

--- a/src/survey/survey.entity.ts
+++ b/src/survey/survey.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany, In } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
 import { Question } from '../question/question.entity';
 import { BaseEntity } from '../base/base.entity';
 import { ObjectType, Field, Int } from '@nestjs/graphql';
@@ -18,13 +25,24 @@ export class Survey extends BaseEntity {
   @Column({ nullable: true })
   description: string;
 
-  @Field(() => [Question], { nullable: true })
-  @OneToMany(() => Question, (question) => question.survey, {
-    cascade: true,
-  })
-  questions: Question[];
+  @OneToMany(() => SurveyQuestion, (surveyQuestion) => surveyQuestion.survey)
+  surveyQuestions: SurveyQuestion[];
 
   @Field()
   @Column({ default: false })
   isCompleted: boolean;
+}
+
+@Entity()
+export class SurveyQuestion extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Survey, (survey) => survey.surveyQuestions)
+  @JoinColumn({ name: 'surveyId' })
+  survey: Survey;
+
+  @ManyToOne(() => Question, (question) => question.surveyQuestions)
+  @JoinColumn({ name: 'questionId' })
+  question: Question;
 }

--- a/src/survey/survey.entity.ts
+++ b/src/survey/survey.entity.ts
@@ -25,6 +25,7 @@ export class Survey extends BaseEntity {
   @Column({ nullable: true })
   description: string;
 
+  @Field(() => [SurveyQuestion], { nullable: true })
   @OneToMany(() => SurveyQuestion, (surveyQuestion) => surveyQuestion.survey)
   surveyQuestions: SurveyQuestion[];
 
@@ -33,15 +34,19 @@ export class Survey extends BaseEntity {
   isCompleted: boolean;
 }
 
+@ObjectType()
 @Entity()
 export class SurveyQuestion extends BaseEntity {
+  @Field(() => Int)
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Field(() => Survey)
   @ManyToOne(() => Survey, (survey) => survey.surveyQuestions)
   @JoinColumn({ name: 'surveyId' })
   survey: Survey;
 
+  @Field(() => Question)
   @ManyToOne(() => Question, (question) => question.surveyQuestions)
   @JoinColumn({ name: 'questionId' })
   question: Question;

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -4,8 +4,13 @@ import { SurveyResolver } from './survey.resolver';
 import { SurveyRepository } from './survey.repository';
 import { DatabaseModule } from '../database/database.module';
 import { AnswerModule } from '../answer/answer.module';
+import { QuestionModule } from '../question/question.module';
 @Module({
-  imports: [DatabaseModule, forwardRef(() => AnswerModule)],
+  imports: [
+    DatabaseModule,
+    forwardRef(() => AnswerModule),
+    forwardRef(() => QuestionModule),
+  ],
   providers: [SurveyService, SurveyResolver, ...SurveyRepository],
   exports: [SurveyService, ...SurveyRepository],
 })

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -1,11 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { SurveyService } from './survey.service';
 import { SurveyResolver } from './survey.resolver';
 import { SurveyRepository } from './survey.repository';
 import { DatabaseModule } from '../database/database.module';
-
+import { AnswerModule } from '../answer/answer.module';
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, forwardRef(() => AnswerModule)],
   providers: [SurveyService, SurveyResolver, ...SurveyRepository],
   exports: [SurveyService, ...SurveyRepository],
 })

--- a/src/survey/survey.repository.ts
+++ b/src/survey/survey.repository.ts
@@ -1,10 +1,16 @@
-import { Survey } from './survey.entity';
+import { Survey, SurveyQuestion } from './survey.entity';
 import { DataSource } from 'typeorm';
 
 export const SurveyRepository = [
   {
     provide: 'SURVEY_REPOSITORY',
     useFactory: (dataSource: DataSource) => dataSource.getRepository(Survey),
+    inject: ['DATA_SOURCE'],
+  },
+  {
+    provide: 'SURVEY_QUESTION_REPOSITORY',
+    useFactory: (dataSource: DataSource) =>
+      dataSource.getRepository(SurveyQuestion),
     inject: ['DATA_SOURCE'],
   },
 ];

--- a/src/survey/survey.resolver.ts
+++ b/src/survey/survey.resolver.ts
@@ -52,4 +52,9 @@ export class SurveyResolver {
   ): Promise<Boolean> {
     return this.surveyService.completeSurvey(id, completeSurveyInput);
   }
+
+  @Query(() => [Survey])
+  async getCompletedSurveys() {
+    return this.surveyService.findCompletedSurveys();
+  }
 }

--- a/src/survey/survey.resolver.ts
+++ b/src/survey/survey.resolver.ts
@@ -57,4 +57,9 @@ export class SurveyResolver {
   async getCompletedSurveys() {
     return this.surveyService.findCompletedSurveys();
   }
+
+  @Query(() => Int)
+  async getSurveyTotalScore(@Args('id', { type: () => Int }) id: number) {
+    return this.surveyService.calculateTotalScore(id);
+  }
 }

--- a/src/survey/survey.resolver.ts
+++ b/src/survey/survey.resolver.ts
@@ -1,7 +1,11 @@
-import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
+import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql';
 import { SurveyService } from './survey.service';
 import { Survey } from './survey.entity';
-import { CreateSurveyInput, UpdateSurveyInput } from './dto/survey.input';
+import {
+  CompleteSurveyInput,
+  CreateSurveyInput,
+  UpdateSurveyInput,
+} from './dto/survey.input';
 
 @Resolver((of) => Survey)
 export class SurveyResolver {
@@ -36,5 +40,13 @@ export class SurveyResolver {
   @Mutation((returns) => Boolean)
   async deleteSurvey(@Args('id') id: number) {
     return this.surveyService.remove(id);
+  }
+
+  @Mutation((returns) => Boolean)
+  async completeSurvey(
+    @Args('id', { type: () => Int }) id: number,
+    @Args('completeSurveyInput') completeSurveyInput: CompleteSurveyInput,
+  ): Promise<Boolean> {
+    return this.surveyService.completeSurvey(id, completeSurveyInput);
   }
 }

--- a/src/survey/survey.resolver.ts
+++ b/src/survey/survey.resolver.ts
@@ -6,8 +6,11 @@ import {
   CreateSurveyInput,
   UpdateSurveyInput,
 } from './dto/survey.input';
+import { UseFilters } from '@nestjs/common';
+import { GqlHttpExceptionFilter } from '../base/filters/gql-http-exception.filter';
 
 @Resolver((of) => Survey)
+@UseFilters(GqlHttpExceptionFilter)
 export class SurveyResolver {
   constructor(private surveyService: SurveyService) {}
 

--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -104,4 +104,8 @@ export class SurveyService {
     this.logger.log(`Completed survey with ID ${id}`);
     return isSuccess;
   }
+
+  async findCompletedSurveys(): Promise<Survey[]> {
+    return this.surveyRepository.find({ where: { isCompleted: true } });
+  }
 }

--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -1,12 +1,20 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Repository, EntityManager, DataSource, In } from 'typeorm';
 import { Survey } from './survey.entity';
-import { CreateSurveyInput, UpdateSurveyInput } from './dto/survey.input';
-
+import {
+  CompleteSurveyInput,
+  CreateSurveyInput,
+  UpdateSurveyInput,
+} from './dto/survey.input';
+import { Answer } from '../answer/answer.entity';
+import { Question } from '../question/question.entity';
+import { Option } from '../option/option.entity';
 @Injectable()
 export class SurveyService {
+  private readonly logger = new Logger(SurveyService.name);
   constructor(
+    @Inject('DATA_SOURCE')
+    private dataSource: DataSource,
     @Inject('SURVEY_REPOSITORY')
     private surveyRepository: Repository<Survey>,
   ) {}
@@ -48,5 +56,52 @@ export class SurveyService {
       throw new NotFoundException(`Survey with ID ${id} not found`);
     }
     return true;
+  }
+
+  async completeSurvey(
+    id: number,
+    completeSurveyInput: CompleteSurveyInput,
+  ): Promise<Boolean> {
+    let isSuccess = false;
+    await this.dataSource.transaction(async (manager: EntityManager) => {
+      const { answers } = completeSurveyInput;
+      const survey = await manager.findOne(Survey, { where: { id } });
+      if (!survey) {
+        throw new NotFoundException(`Survey with ID ${id} not found`);
+      }
+      const questionIds = answers.map((answer) => answer.questionId);
+      const optionIds = answers.map((answer) => answer.selectedOptionId);
+
+      const questions = await manager.find(Question, {
+        where: { id: In(questionIds) },
+      });
+      const options = await manager.find(Option, {
+        where: { id: In(optionIds) },
+      });
+
+      for (const answer of answers) {
+        const { questionId, selectedOptionId } = answer;
+        const question = questions.find((q) => q.id === questionId);
+        const selectedOption = options.find((o) => o.id === selectedOptionId);
+
+        if (!question || !selectedOption) {
+          throw new NotFoundException(`Question or Option not found`);
+        }
+
+        const answerEntity = manager.create(Answer, {
+          question,
+          selectedOption,
+        });
+
+        await manager.save(answerEntity);
+      }
+
+      survey.isCompleted = true;
+
+      await this.surveyRepository.save(survey);
+      isSuccess = true;
+    });
+    this.logger.log(`Completed survey with ID ${id}`);
+    return isSuccess;
   }
 }

--- a/src/survey/tests/survey.resolver.spec.ts
+++ b/src/survey/tests/survey.resolver.spec.ts
@@ -13,6 +13,7 @@ describe('SurveyResolver', () => {
       create: jest.fn(),
       update: jest.fn(),
       remove: jest.fn(),
+      completeSurvey: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -78,5 +79,25 @@ describe('SurveyResolver', () => {
 
     expect(await resolver.deleteSurvey(surveyId)).toEqual(true);
     expect(mockSurveyService.remove).toHaveBeenCalledWith(surveyId);
+  });
+
+  it('complete a survey', async () => {
+    const surveyId = 1;
+    const completeSurveyInput = {
+      answers: [
+        { questionId: 1, selectedOptionId: 1 },
+        { questionId: 2, selectedOptionId: 2 },
+      ],
+    };
+    const expectedSurvey = { id: surveyId, ...completeSurveyInput };
+    mockSurveyService.completeSurvey.mockResolvedValue(expectedSurvey);
+
+    expect(
+      await resolver.completeSurvey(surveyId, completeSurveyInput),
+    ).toEqual(expectedSurvey);
+    expect(mockSurveyService.completeSurvey).toHaveBeenCalledWith(
+      surveyId,
+      completeSurveyInput,
+    );
   });
 });


### PR DESCRIPTION
# 주요 변경 사항
- [x] 설문지 완료 기능 추가
    - [x] 설문지 완료 리졸버 및 input 타입 추가
    - [x] 완료된 설문지 조회 기능 추가
- [x] 설문지 답변 총점 확인
- [x] graphql 예외 처리 관련 필터 추가
- [x] 설문지, 질문 다대다 관계를 위한 테이블 추가
    - [x] 설문지, 질문 create 수정
- [x] 단위 테스트, e2e  추가

## 기타

### 설문지 완료 기능 
Input 값을 문항과 답변의 리스트로 받음 완료 처리할 때는 문항과 선택지에 맞게 답변을 생성함.
그 뒤 설문지 엔티티의 isCompleted 필드가 있고 이걸 업데이트 함.
완료된 설문지를 확인하는 로직은 isCompleted  이 필드를 체크해서 가져옴

### 설문지 총점 계산
중복 응답 고려해서 계산함

